### PR TITLE
Update sbt version and plugin versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 name := "futiles"
 organization := "com.markatta"
 
-crossScalaVersions := Seq("2.12.3", "2.11.11", "2.13.0")
+crossScalaVersions := Seq("2.12.15", "2.11.12", "2.13.8")
 scalaVersion := crossScalaVersions.value.last
 scalacOptions ++= Seq("-feature", "-deprecation", "-Xfatal-warnings", "-Xlint")
 
@@ -16,7 +16,7 @@ licenses := Seq(
 )
 homepage := Some(url("https://github.com/johanandren/futiles"))
 publishMavenStyle := true
-publishArtifact in Test := false
+Test / publishArtifact := false
 pomIncludeRepository := { _ =>
   false
 }
@@ -28,16 +28,10 @@ publishTo := Some {
     "releases" at nexus + "service/local/staging/deploy/maven2"
 }
 
-pomExtra :=
-  <scm>
-    <url>git@github.com:johanandren/futiles.git</url>
-    <connection>scm:git:git@github.com:johanandren/futiles.git</connection>
-  </scm>
-  <developers>
-    <developer>
-      <id>johanandren</id>
-      <name>Johan Andrén</name>
-      <email>johan@markatta.com</email>
-      <url>https://markatta.com/johan/codemonkey</url>
-    </developer>
-  </developers>
+scmInfo := Some(
+  ScmInfo(url("https://github.com/johanandren/futiles"), "git@github.com:johanandren/futiles.git")
+)
+
+developers := List(
+  Developer("johanandren", "Johan Andrén", "johan@markatta.com", url("https://markatta.com/johan/codemonkey"))
+)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.0
+sbt.version=1.6.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "3.0.0")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")

--- a/project/release.sbt
+++ b/project/release.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.11")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.1.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.0.2-SNAPSHOT"
+ThisBuild / version := "2.0.2-SNAPSHOT"


### PR DESCRIPTION
This PR updates the SBT version and along with it also cleans up `build.sbt`. It also updates the various sbt plugin versions. It also updates the Scala versions to their latest counterparts.