### PR TITLE
Add and apply scalafmt

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,26 @@
+name: Scalafmt
+
+on:
+  pull_request:
+    branches: ['**']
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  build:
+    name: Code is formatted
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Check project is formatted
+        uses: jrouly/scalafmt-native-action@v1
+        with:
+          version: '3.4.3'

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,11 @@
+version = 3.4.3
+runner.dialect = scala213
+preset = default
+align.preset = more
+maxColumn = 120
+project.git = true
+align.openParenDefnSite = true
+align.openParenCallSite = true
+align.arrowEnumeratorGenerator = true
+danglingParentheses.preset = true
+rewrite.rules = [RedundantBraces, RedundantParens]

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
-ThisBuild / name := "futiles"
+ThisBuild / name         := "futiles"
 ThisBuild / organization := "com.markatta"
 
 ThisBuild / crossScalaVersions := Seq("2.12.15", "2.11.12", "2.13.8")
-ThisBuild / scalaVersion := crossScalaVersions.value.last
+ThisBuild / scalaVersion       := crossScalaVersions.value.last
 ThisBuild / scalacOptions ++= Seq("-feature", "-deprecation", "-Xfatal-warnings", "-Xlint")
 
 libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.0.8" % "test")
@@ -14,8 +14,8 @@ licenses := Seq(
     "http://www.apache.org/licenses/LICENSE-2.0"
   )
 )
-homepage := Some(url("https://github.com/johanandren/futiles"))
-publishMavenStyle := true
+homepage               := Some(url("https://github.com/johanandren/futiles"))
+publishMavenStyle      := true
 Test / publishArtifact := false
 pomIncludeRepository := { _ =>
   false

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")
 
 addSbtPlugin("com.codecommit" % "sbt-github-actions" % "0.14.2")
+
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")
-
-addSbtPlugin("com.codecommit" % "sbt-github-actions" % "0.14.2")
-
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
+addSbtPlugin("de.heikoseeberger" % "sbt-header"         % "5.6.0")
+addSbtPlugin("com.codecommit"    % "sbt-github-actions" % "0.14.2")
+addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.4.6")

--- a/src/main/scala-2.11/markatta/futiles/Sequencing.scala
+++ b/src/main/scala-2.11/markatta/futiles/Sequencing.scala
@@ -21,63 +21,58 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.language.higherKinds
 import scala.util.Try
 
-/**
- * Functions for transforming something with a future inside into a future with something inside
- */
+/** Functions for transforming something with a future inside into a future with something inside
+  */
 object Sequencing {
 
-  /**
-   * Turn an option of a future inside out, much like Future.sequence but keep it an Option
-   */
+  /** Turn an option of a future inside out, much like Future.sequence but keep it an Option
+    */
   def sequenceOpt[A](f: Option[Future[A]]): Future[Option[A]] =
     f.map(_.map(Some(_))(CallingThreadExecutionContext)).getOrElse(Future.successful(None))
 
-
-  /**
-   * @return a Future(Left(l)) for a Left(Future(l)) and a Future(Right(r)) for a Right(Future(r))
-   */
+  /** @return
+    *   a Future(Left(l)) for a Left(Future(l)) and a Future(Right(r)) for a Right(Future(r))
+    */
   def sequenceEither[L, R](either: Either[Future[L], Future[R]]): Future[Either[L, R]] =
     either.fold(
       lf => lf.map(l => Left[L, R](l))(CallingThreadExecutionContext),
       rf => rf.map(r => Right[L, R](r))(CallingThreadExecutionContext)
     )
 
-  /**
-   * @return a Future(Left(l)) for a Left(Future(l)) and a Future(Right(r)) for a Right(r)
-   */
+  /** @return
+    *   a Future(Left(l)) for a Left(Future(l)) and a Future(Right(r)) for a Right(r)
+    */
   def sequenceL[L, R](either: Either[Future[L], R]): Future[Either[L, R]] =
     sequenceEither(either.right.map(Future.successful))
 
-  /**
-   * @return a Future(Left(l)) for a Left(l) and a Future(Right(r)) for a Right(Future(r))
-   */
+  /** @return
+    *   a Future(Left(l)) for a Left(l) and a Future(Right(r)) for a Right(Future(r))
+    */
   def sequenceR[L, R](either: Either[L, Future[R]]): Future[Either[L, R]] =
     sequenceEither(either.left.map(Future.successful))
 
-
-  /**
-   * Like Future.sequence() but instead of failing the result future when one future fails
-   * it will collect each success or failure and complete once all futures has either failed or succeeded
-   *
-   * @return A future that completes once all the given futures has completed, successfully or failed, so
-   *         that all of the failures can be handled, reported etc.
-   * @see Lifting.liftTry()
-   */
+  /** Like Future.sequence() but instead of failing the result future when one future fails it will collect each success
+    * or failure and complete once all futures has either failed or succeeded
+    *
+    * @return
+    *   A future that completes once all the given futures has completed, successfully or failed, so that all of the
+    *   failures can be handled, reported etc.
+    * @see
+    *   Lifting.liftTry()
+    */
   def sequenceTries[A, M[X] <: TraversableOnce[X]](
-    fas: M[Future[A]]
-  )(
-    implicit ec: ExecutionContext, cbf: CanBuildFrom[M[Future[A]], Try[A], M[Try[A]]]
+      fas: M[Future[A]]
+  )(implicit
+      ec: ExecutionContext,
+      cbf: CanBuildFrom[M[Future[A]], Try[A], M[Try[A]]]
   ): Future[M[Try[A]]] = {
     val fts = fas.foldLeft(Future.successful(cbf())) { (facc, fa) =>
       for {
         acc <- facc
-        ta <- Lifting.liftTry(fa)
+        ta  <- Lifting.liftTry(fa)
       } yield acc += ta
     }
     fts.map(_.result())
   }
-
-
-
 
 }

--- a/src/main/scala-2.11/markatta/futiles/Traversal.scala
+++ b/src/main/scala-2.11/markatta/futiles/Traversal.scala
@@ -20,29 +20,33 @@ import scala.collection.generic.CanBuildFrom
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.higherKinds
 
-/**
- * Utilities that complement scala.concurrent.Future.traverse, working with creating a future out of each element
- * in a collection and collecting those into a single future.
- */
+/** Utilities that complement scala.concurrent.Future.traverse, working with creating a future out of each element in a
+  * collection and collecting those into a single future.
+  */
 object Traversal {
 
-  /**
-   * For each ```A``` apply the function ```f```, and wait for it to complete before continuing with the next ```A```
-   *
-   * @return The future all ```A```s turned into ```B``` or the first failure that occurred
-   */
-  def traverseSequentially[A, B, M[X] <: TraversableOnce[X]](as: M[A])(f: A => Future[B])(implicit ec: ExecutionContext, cbf: CanBuildFrom[M[A], B, M[B]]): Future[M[B]] =
+  /** For each ```A``` apply the function ```f```, and wait for it to complete before continuing with the next ```A```
+    *
+    * @return
+    *   The future all ```A```s turned into ```B``` or the first failure that occurred
+    */
+  def traverseSequentially[A, B, M[X] <: TraversableOnce[X]](as: M[A])(
+      f: A => Future[B]
+  )(implicit ec: ExecutionContext, cbf: CanBuildFrom[M[A], B, M[B]]): Future[M[B]] =
     foldLeftSequentially(as.toTraversable)(cbf())((builder, a) => f(a).map(b => builder += b)).map(_.result())
 
-  /**
-   * Like a regular fold left, but with an operation that returns futures, each future will complete before the next
-   * element in ```as``` is executed.
-   *
-   * @param z The zero value, if ```as``` is empty, this is returned, if not this is fed into ```f``` as the ```B``` value
-   * @return The future of all ```A``` folded into ```B```s, or a future that is failed with any exception that is thrown
-   *         from f
-   */
-  def foldLeftSequentially[A, B](as: Traversable[A])(z: B)(f: (B, A) => Future[B])(implicit ec: ExecutionContext): Future[B] =
+  /** Like a regular fold left, but with an operation that returns futures, each future will complete before the next
+    * element in ```as``` is executed.
+    *
+    * @param z
+    *   The zero value, if ```as``` is empty, this is returned, if not this is fed into ```f``` as the ```B``` value
+    * @return
+    *   The future of all ```A``` folded into ```B```s, or a future that is failed with any exception that is thrown
+    *   from f
+    */
+  def foldLeftSequentially[A, B](
+      as: Traversable[A]
+  )(z: B)(f: (B, A) => Future[B])(implicit ec: ExecutionContext): Future[B] =
     if (as.isEmpty) Future.successful(z)
     else f(z, as.head).flatMap(b => foldLeftSequentially(as.tail)(b)(f))
 

--- a/src/main/scala-2.12/markatta/futiles/Sequencing.scala
+++ b/src/main/scala-2.12/markatta/futiles/Sequencing.scala
@@ -21,63 +21,58 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.language.higherKinds
 import scala.util.Try
 
-/**
- * Functions for transforming something with a future inside into a future with something inside
- */
+/** Functions for transforming something with a future inside into a future with something inside
+  */
 object Sequencing {
 
-  /**
-   * Turn an option of a future inside out, much like Future.sequence but keep it an Option
-   */
+  /** Turn an option of a future inside out, much like Future.sequence but keep it an Option
+    */
   def sequenceOpt[A](f: Option[Future[A]]): Future[Option[A]] =
     f.map(_.map(Some(_))(CallingThreadExecutionContext)).getOrElse(Future.successful(None))
 
-
-  /**
-   * @return a Future(Left(l)) for a Left(Future(l)) and a Future(Right(r)) for a Right(Future(r))
-   */
+  /** @return
+    *   a Future(Left(l)) for a Left(Future(l)) and a Future(Right(r)) for a Right(Future(r))
+    */
   def sequenceEither[L, R](either: Either[Future[L], Future[R]]): Future[Either[L, R]] =
     either.fold(
       lf => lf.map(l => Left[L, R](l))(CallingThreadExecutionContext),
       rf => rf.map(r => Right[L, R](r))(CallingThreadExecutionContext)
     )
 
-  /**
-   * @return a Future(Left(l)) for a Left(Future(l)) and a Future(Right(r)) for a Right(r)
-   */
+  /** @return
+    *   a Future(Left(l)) for a Left(Future(l)) and a Future(Right(r)) for a Right(r)
+    */
   def sequenceL[L, R](either: Either[Future[L], R]): Future[Either[L, R]] =
     sequenceEither(either.right.map(Future.successful))
 
-  /**
-   * @return a Future(Left(l)) for a Left(l) and a Future(Right(r)) for a Right(Future(r))
-   */
+  /** @return
+    *   a Future(Left(l)) for a Left(l) and a Future(Right(r)) for a Right(Future(r))
+    */
   def sequenceR[L, R](either: Either[L, Future[R]]): Future[Either[L, R]] =
     sequenceEither(either.left.map(Future.successful))
 
-
-  /**
-   * Like Future.sequence() but instead of failing the result future when one future fails
-   * it will collect each success or failure and complete once all futures has either failed or succeeded
-   *
-   * @return A future that completes once all the given futures has completed, successfully or failed, so
-   *         that all of the failures can be handled, reported etc.
-   * @see Lifting.liftTry()
-   */
+  /** Like Future.sequence() but instead of failing the result future when one future fails it will collect each success
+    * or failure and complete once all futures has either failed or succeeded
+    *
+    * @return
+    *   A future that completes once all the given futures has completed, successfully or failed, so that all of the
+    *   failures can be handled, reported etc.
+    * @see
+    *   Lifting.liftTry()
+    */
   def sequenceTries[A, M[X] <: TraversableOnce[X]](
-    fas: M[Future[A]]
-  )(
-    implicit ec: ExecutionContext, cbf: CanBuildFrom[M[Future[A]], Try[A], M[Try[A]]]
+      fas: M[Future[A]]
+  )(implicit
+      ec: ExecutionContext,
+      cbf: CanBuildFrom[M[Future[A]], Try[A], M[Try[A]]]
   ): Future[M[Try[A]]] = {
     val fts = fas.foldLeft(Future.successful(cbf())) { (facc, fa) =>
       for {
         acc <- facc
-        ta <- Lifting.liftTry(fa)
+        ta  <- Lifting.liftTry(fa)
       } yield acc += ta
     }
     fts.map(_.result())
   }
-
-
-
 
 }

--- a/src/main/scala-2.12/markatta/futiles/Traversal.scala
+++ b/src/main/scala-2.12/markatta/futiles/Traversal.scala
@@ -20,29 +20,33 @@ import scala.collection.generic.CanBuildFrom
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.higherKinds
 
-/**
- * Utilities that complement scala.concurrent.Future.traverse, working with creating a future out of each element
- * in a collection and collecting those into a single future.
- */
+/** Utilities that complement scala.concurrent.Future.traverse, working with creating a future out of each element in a
+  * collection and collecting those into a single future.
+  */
 object Traversal {
 
-  /**
-   * For each ```A``` apply the function ```f```, and wait for it to complete before continuing with the next ```A```
-   *
-   * @return The future all ```A```s turned into ```B``` or the first failure that occurred
-   */
-  def traverseSequentially[A, B, M[X] <: TraversableOnce[X]](as: M[A])(f: A => Future[B])(implicit ec: ExecutionContext, cbf: CanBuildFrom[M[A], B, M[B]]): Future[M[B]] =
+  /** For each ```A``` apply the function ```f```, and wait for it to complete before continuing with the next ```A```
+    *
+    * @return
+    *   The future all ```A```s turned into ```B``` or the first failure that occurred
+    */
+  def traverseSequentially[A, B, M[X] <: TraversableOnce[X]](as: M[A])(
+      f: A => Future[B]
+  )(implicit ec: ExecutionContext, cbf: CanBuildFrom[M[A], B, M[B]]): Future[M[B]] =
     foldLeftSequentially(as.toTraversable)(cbf())((builder, a) => f(a).map(b => builder += b)).map(_.result())
 
-  /**
-   * Like a regular fold left, but with an operation that returns futures, each future will complete before the next
-   * element in ```as``` is executed.
-   *
-   * @param z The zero value, if ```as``` is empty, this is returned, if not this is fed into ```f``` as the ```B``` value
-   * @return The future of all ```A``` folded into ```B```s, or a future that is failed with any exception that is thrown
-   *         from f
-   */
-  def foldLeftSequentially[A, B](as: Traversable[A])(z: B)(f: (B, A) => Future[B])(implicit ec: ExecutionContext): Future[B] =
+  /** Like a regular fold left, but with an operation that returns futures, each future will complete before the next
+    * element in ```as``` is executed.
+    *
+    * @param z
+    *   The zero value, if ```as``` is empty, this is returned, if not this is fed into ```f``` as the ```B``` value
+    * @return
+    *   The future of all ```A``` folded into ```B```s, or a future that is failed with any exception that is thrown
+    *   from f
+    */
+  def foldLeftSequentially[A, B](
+      as: Traversable[A]
+  )(z: B)(f: (B, A) => Future[B])(implicit ec: ExecutionContext): Future[B] =
     if (as.isEmpty) Future.successful(z)
     else f(z, as.head).flatMap(b => foldLeftSequentially(as.tail)(b)(f))
 

--- a/src/main/scala-2.13/markatta/futiles/Traversal.scala
+++ b/src/main/scala-2.13/markatta/futiles/Traversal.scala
@@ -19,35 +19,33 @@ package markatta.futiles
 import scala.collection.BuildFrom
 import scala.concurrent.{ExecutionContext, Future}
 
-/**
-  * Utilities that complement scala.concurrent.Future.traverse, working with creating a future out of each element
-  * in a collection and collecting those into a single future.
+/** Utilities that complement scala.concurrent.Future.traverse, working with creating a future out of each element in a
+  * collection and collecting those into a single future.
   */
 object Traversal {
 
-  /**
-    * For each ```A``` apply the function ```f```, and wait for it to complete before continuing with the next ```A```
+  /** For each ```A``` apply the function ```f```, and wait for it to complete before continuing with the next ```A```
     *
-    * @return The future all ```A```s turned into ```B``` or the first failure that occurred
+    * @return
+    *   The future all ```A```s turned into ```B``` or the first failure that occurred
     */
   def traverseSequentially[A, B, M[X] <: IterableOnce[X]](
-    as: M[A]
-  )(f: A => Future[B])(implicit ec: ExecutionContext,
-                       cbf: BuildFrom[M[A], B, M[B]]): Future[M[B]] =
-    foldLeftSequentially(as.iterator.to(Iterable))(cbf.newBuilder(as))(
-      (builder, a) => f(a).map(b => builder += b)
-    ).map(_.result())
+      as: M[A]
+  )(f: A => Future[B])(implicit ec: ExecutionContext, cbf: BuildFrom[M[A], B, M[B]]): Future[M[B]] =
+    foldLeftSequentially(as.iterator.to(Iterable))(cbf.newBuilder(as))((builder, a) => f(a).map(b => builder += b))
+      .map(_.result())
 
-  /**
-    * Like a regular fold left, but with an operation that returns futures, each future will complete before the next
+  /** Like a regular fold left, but with an operation that returns futures, each future will complete before the next
     * element in ```as``` is executed.
     *
-    * @param z The zero value, if ```as``` is empty, this is returned, if not this is fed into ```f``` as the ```B``` value
-    * @return The future of all ```A``` folded into ```B```s, or a future that is failed with any exception that is thrown
-    *         from f
+    * @param z
+    *   The zero value, if ```as``` is empty, this is returned, if not this is fed into ```f``` as the ```B``` value
+    * @return
+    *   The future of all ```A``` folded into ```B```s, or a future that is failed with any exception that is thrown
+    *   from f
     */
   def foldLeftSequentially[A, B](
-    as: Iterable[A]
+      as: Iterable[A]
   )(z: B)(f: (B, A) => Future[B])(implicit ec: ExecutionContext): Future[B] =
     if (as.isEmpty) Future.successful(z)
     else f(z, as.head).flatMap(b => foldLeftSequentially(as.tail)(b)(f))

--- a/src/main/scala/markatta/futiles/Boolean.scala
+++ b/src/main/scala/markatta/futiles/Boolean.scala
@@ -18,24 +18,23 @@ package markatta.futiles
 
 import scala.concurrent.{ExecutionContext, Future}
 
-/**
- * Boolean algebra composition operations for Future[Boolean]
- *
- * Credit goes to http://stackoverflow.com/users/3235823/dwickern for the idea to do this.
- */
+/** Boolean algebra composition operations for Future[Boolean]
+  *
+  * Credit goes to http://stackoverflow.com/users/3235823/dwickern for the idea to do this.
+  */
 object Boolean {
 
-  /**
-   * @return A new future that will be true if both futures are true, if this one
-   *         is false the second one will not be evaluated (just like with regular booleans).
-   */
+  /** @return
+    *   A new future that will be true if both futures are true, if this one is false the second one will not be
+    *   evaluated (just like with regular booleans).
+    */
   def and(fb: Future[Boolean], other: => Future[Boolean])(implicit ec: ExecutionContext) =
     fb.flatMap(b => if (!b) Future.successful(false) else other)
 
-  /**
-   * @return A new future that will be true if either future is true, if this one
-   *         is true the second one will not be evaluated (just like with regular booleans).
-   */
+  /** @return
+    *   A new future that will be true if either future is true, if this one is true the second one will not be
+    *   evaluated (just like with regular booleans).
+    */
   def or(fb: Future[Boolean], other: => Future[Boolean])(implicit ec: ExecutionContext) =
     fb.flatMap(b => if (b) Future.successful(true) else other)
 
@@ -46,17 +45,17 @@ object Boolean {
 
     implicit class FutureBooleanDecorator(val fb: Future[Boolean]) extends AnyVal {
 
-      /**
-       * @return A new future that will be true if both futures are true, if this one
-       *         is false the second one will not be evaluated (just like with regular booleans).
-       */
+      /** @return
+        *   A new future that will be true if both futures are true, if this one is false the second one will not be
+        *   evaluated (just like with regular booleans).
+        */
       def &&(other: => Future[Boolean])(implicit ec: ExecutionContext) =
         and(fb, other)(ec)
 
-      /**
-       * @return A new future that will be true if either future is true, if this one
-       *         is true the second one will not be evaluated (just like with regular booleans).
-       */
+      /** @return
+        *   A new future that will be true if either future is true, if this one is true the second one will not be
+        *   evaluated (just like with regular booleans).
+        */
       def ||(other: => Future[Boolean])(implicit ec: ExecutionContext) =
         or(fb, other)
 

--- a/src/main/scala/markatta/futiles/CallingThreadExecutionContext.scala
+++ b/src/main/scala/markatta/futiles/CallingThreadExecutionContext.scala
@@ -5,13 +5,12 @@ package markatta.futiles
 
 import scala.concurrent.ExecutionContext
 
-/**
- * This is a common optimization that allows us to avoid scheduling future transformations
- * for execution on the execution context but instead just run them on the calling thread.
- * Should never be used for anything but simple quick transformations.
- */
+/** This is a common optimization that allows us to avoid scheduling future transformations for execution on the
+  * execution context but instead just run them on the calling thread. Should never be used for anything but simple
+  * quick transformations.
+  */
 private[futiles] object CallingThreadExecutionContext extends ExecutionContext {
-  override def execute(runnable: Runnable): Unit = runnable.run()
+  override def execute(runnable: Runnable): Unit     = runnable.run()
   override def reportFailure(cause: Throwable): Unit = throw cause
-  implicit def Implicit: ExecutionContext = this
+  implicit def Implicit: ExecutionContext            = this
 }

--- a/src/main/scala/markatta/futiles/Combining.scala
+++ b/src/main/scala/markatta/futiles/Combining.scala
@@ -25,196 +25,213 @@ object Combining {
 
   import CallingThreadExecutionContext.Implicit
 
-  /**
-   * Combine two future values into a tuple when they arrive, or fail as soon as either of them fails
-   * (just an alias for Future.zip)
-   */
-  def product[A,B](fa: Future[A], fb: Future[B]): Future[(A, B)] = {
+  /** Combine two future values into a tuple when they arrive, or fail as soon as either of them fails (just an alias
+    * for Future.zip)
+    */
+  def product[A, B](fa: Future[A], fb: Future[B]): Future[(A, B)] = {
     val promise = Promise[(A, B)]()
-    val ref = new AtomicReference[(A, B)]((null.asInstanceOf[A], null.asInstanceOf[B]))
+    val ref     = new AtomicReference[(A, B)]((null.asInstanceOf[A], null.asInstanceOf[B]))
     def tryUpdate(mod: (A, B) => (A, B)): Unit = {
       val original = ref.get()
-      val updated = mod.tupled(original)
+      val updated  = mod.tupled(original)
       if (updated._1 != null && updated._2 != null) promise.trySuccess(updated)
       else if (ref.compareAndSet(original, updated)) ()
       else tryUpdate(mod)
     }
 
     fa.onComplete {
-      case Success(a) => tryUpdate((_, b) => (a, b))
+      case Success(a)  => tryUpdate((_, b) => (a, b))
       case Failure(ex) => promise.tryFailure(ex)
     }
 
     fb.onComplete {
-      case Success(b) => tryUpdate((a, _) => (a, b))
+      case Success(b)  => tryUpdate((a, _) => (a, b))
       case Failure(ex) => promise.tryFailure(ex)
     }
 
     promise.future
   }
 
-  /**
-   * Combine three future values into a tuple when they arrive, or fail as soon as any one of them fails
-   */
+  /** Combine three future values into a tuple when they arrive, or fail as soon as any one of them fails
+    */
   def product[A, B, C](fa: Future[A], fb: Future[B], fc: Future[C]): Future[(A, B, C)] = {
     val promise = Promise[(A, B, C)]()
-    val ref = new AtomicReference[(A, B, C)]((null.asInstanceOf[A], null.asInstanceOf[B], null.asInstanceOf[C]))
+    val ref     = new AtomicReference[(A, B, C)]((null.asInstanceOf[A], null.asInstanceOf[B], null.asInstanceOf[C]))
     def tryUpdate(mod: (A, B, C) => (A, B, C)): Unit = {
       val original = ref.get()
-      val updated = mod.tupled(original)
+      val updated  = mod.tupled(original)
       if (updated._1 != null && updated._2 != null && updated._3 != null) promise.trySuccess(updated)
       else if (ref.compareAndSet(original, updated)) ()
       else tryUpdate(mod)
     }
 
     fa.onComplete {
-      case Success(a) => tryUpdate((_, b, c) => (a, b, c))
+      case Success(a)  => tryUpdate((_, b, c) => (a, b, c))
       case Failure(ex) => promise.tryFailure(ex)
     }
 
     fb.onComplete {
-      case Success(b) => tryUpdate((a, _, c) => (a, b, c))
+      case Success(b)  => tryUpdate((a, _, c) => (a, b, c))
       case Failure(ex) => promise.tryFailure(ex)
     }
 
     fc.onComplete {
-      case Success(c) => tryUpdate((a, b, _) => (a, b, c))
+      case Success(c)  => tryUpdate((a, b, _) => (a, b, c))
       case Failure(ex) => promise.tryFailure(ex)
     }
 
     promise.future
   }
 
-
-  /**
-   * Combine four future values into a tuple when they arrive, or fail as soon as any one of them fails
-   */
+  /** Combine four future values into a tuple when they arrive, or fail as soon as any one of them fails
+    */
   def product[A, B, C, D](fa: Future[A], fb: Future[B], fc: Future[C], fd: Future[D]): Future[(A, B, C, D)] = {
     val promise = Promise[(A, B, C, D)]()
-    val ref = new AtomicReference[(A, B, C, D)]((null.asInstanceOf[A], null.asInstanceOf[B], null.asInstanceOf[C], null.asInstanceOf[D]))
+    val ref = new AtomicReference[(A, B, C, D)](
+      (null.asInstanceOf[A], null.asInstanceOf[B], null.asInstanceOf[C], null.asInstanceOf[D])
+    )
     def tryUpdate(mod: (A, B, C, D) => (A, B, C, D)): Unit = {
       val original = ref.get()
-      val updated = mod.tupled(original)
-      if (updated._1 != null && updated._2 != null && updated._3 != null && updated._4 != null) promise.trySuccess(updated)
+      val updated  = mod.tupled(original)
+      if (updated._1 != null && updated._2 != null && updated._3 != null && updated._4 != null)
+        promise.trySuccess(updated)
       else if (ref.compareAndSet(original, updated)) ()
       else tryUpdate(mod)
     }
 
     fa.onComplete {
-      case Success(a) => tryUpdate((_, b, c, d) => (a, b, c, d))
+      case Success(a)  => tryUpdate((_, b, c, d) => (a, b, c, d))
       case Failure(ex) => promise.tryFailure(ex)
     }
 
     fb.onComplete {
-      case Success(b) => tryUpdate((a, _, c, d) => (a, b, c, d))
+      case Success(b)  => tryUpdate((a, _, c, d) => (a, b, c, d))
       case Failure(ex) => promise.tryFailure(ex)
     }
 
     fc.onComplete {
-      case Success(c) => tryUpdate((a, b, _, d) => (a, b, c, d))
+      case Success(c)  => tryUpdate((a, b, _, d) => (a, b, c, d))
       case Failure(ex) => promise.tryFailure(ex)
     }
 
     fd.onComplete {
-      case Success(d) => tryUpdate((a, b, c, _) => (a, b, c, d))
+      case Success(d)  => tryUpdate((a, b, c, _) => (a, b, c, d))
       case Failure(ex) => promise.tryFailure(ex)
     }
 
     promise.future
   }
 
-
-
-  /**
-   * Combine five future values into a tuple when they arrive, or fail as soon as any one of them fails
-   */
-  def product[A, B, C, D, E](fa: Future[A], fb: Future[B], fc: Future[C], fd: Future[D], fe: Future[E]): Future[(A, B, C, D, E)] = {
+  /** Combine five future values into a tuple when they arrive, or fail as soon as any one of them fails
+    */
+  def product[A, B, C, D, E](fa: Future[A],
+                             fb: Future[B],
+                             fc: Future[C],
+                             fd: Future[D],
+                             fe: Future[E]
+  ): Future[(A, B, C, D, E)] = {
     val promise = Promise[(A, B, C, D, E)]()
-    val ref = new AtomicReference[(A, B, C, D, E)]((null.asInstanceOf[A], null.asInstanceOf[B], null.asInstanceOf[C], null.asInstanceOf[D], null.asInstanceOf[E]))
+    val ref = new AtomicReference[(A, B, C, D, E)](
+      (null.asInstanceOf[A], null.asInstanceOf[B], null.asInstanceOf[C], null.asInstanceOf[D], null.asInstanceOf[E])
+    )
     def tryUpdate(mod: (A, B, C, D, E) => (A, B, C, D, E)): Unit = {
       val original = ref.get()
-      val updated = mod.tupled(original)
-      if (updated._1 != null && updated._2 != null && updated._3 != null && updated._4 != null && updated._5 != null) promise.trySuccess(updated)
+      val updated  = mod.tupled(original)
+      if (updated._1 != null && updated._2 != null && updated._3 != null && updated._4 != null && updated._5 != null)
+        promise.trySuccess(updated)
       else if (ref.compareAndSet(original, updated)) ()
       else tryUpdate(mod)
     }
 
     fa.onComplete {
-      case Success(a) => tryUpdate((_, b, c, d, e) => (a, b, c, d, e))
+      case Success(a)  => tryUpdate((_, b, c, d, e) => (a, b, c, d, e))
       case Failure(ex) => promise.tryFailure(ex)
     }
 
     fb.onComplete {
-      case Success(b) => tryUpdate((a, _, c, d, e) => (a, b, c, d, e))
+      case Success(b)  => tryUpdate((a, _, c, d, e) => (a, b, c, d, e))
       case Failure(ex) => promise.tryFailure(ex)
     }
 
     fc.onComplete {
-      case Success(c) => tryUpdate((a, b, _, d, e) => (a, b, c, d, e))
+      case Success(c)  => tryUpdate((a, b, _, d, e) => (a, b, c, d, e))
       case Failure(ex) => promise.tryFailure(ex)
     }
 
     fd.onComplete {
-      case Success(d) => tryUpdate((a, b, c, _, e) => (a, b, c, d, e))
+      case Success(d)  => tryUpdate((a, b, c, _, e) => (a, b, c, d, e))
       case Failure(ex) => promise.tryFailure(ex)
     }
 
     fe.onComplete {
-      case Success(e) => tryUpdate((a, b, c, d, _) => (a, b, c, d, e))
+      case Success(e)  => tryUpdate((a, b, c, d, _) => (a, b, c, d, e))
       case Failure(ex) => promise.tryFailure(ex)
     }
 
     promise.future
   }
 
-
-  /**
-   * Combine six future values into a tuple when they arrive, or fail as soon as any one of them fails
-   */
-  def product[A, B, C, D, E, F](fa: Future[A], fb: Future[B], fc: Future[C], fd: Future[D], fe: Future[E], ff: Future[F]): Future[(A, B, C, D, E, F)] ={
+  /** Combine six future values into a tuple when they arrive, or fail as soon as any one of them fails
+    */
+  def product[A, B, C, D, E, F](fa: Future[A],
+                                fb: Future[B],
+                                fc: Future[C],
+                                fd: Future[D],
+                                fe: Future[E],
+                                ff: Future[F]
+  ): Future[(A, B, C, D, E, F)] = {
     val promise = Promise[(A, B, C, D, E, F)]()
-    val ref = new AtomicReference[(A, B, C, D, E, F)]((null.asInstanceOf[A], null.asInstanceOf[B], null.asInstanceOf[C], null.asInstanceOf[D], null.asInstanceOf[E], null.asInstanceOf[F]))
+    val ref = new AtomicReference[(A, B, C, D, E, F)](
+      (null.asInstanceOf[A],
+       null.asInstanceOf[B],
+       null.asInstanceOf[C],
+       null.asInstanceOf[D],
+       null.asInstanceOf[E],
+       null.asInstanceOf[F]
+      )
+    )
     def tryUpdate(mod: (A, B, C, D, E, F) => (A, B, C, D, E, F)): Unit = {
       val original = ref.get()
-      val updated = mod.tupled(original)
-      if (updated._1 != null && updated._2 != null && updated._3 != null && updated._4 != null && updated._5 != null && updated._6 != null) promise.trySuccess(updated)
+      val updated  = mod.tupled(original)
+      if (
+        updated._1 != null && updated._2 != null && updated._3 != null && updated._4 != null && updated._5 != null && updated._6 != null
+      ) promise.trySuccess(updated)
       else if (ref.compareAndSet(original, updated)) ()
       else tryUpdate(mod)
     }
 
     fa.onComplete {
-      case Success(a) => tryUpdate((_, b, c, d, e, f) => (a, b, c, d, e, f))
+      case Success(a)  => tryUpdate((_, b, c, d, e, f) => (a, b, c, d, e, f))
       case Failure(ex) => promise.tryFailure(ex)
     }
 
     fb.onComplete {
-      case Success(b) => tryUpdate((a, _, c, d, e, f) => (a, b, c, d, e, f))
+      case Success(b)  => tryUpdate((a, _, c, d, e, f) => (a, b, c, d, e, f))
       case Failure(ex) => promise.tryFailure(ex)
     }
 
     fc.onComplete {
-      case Success(c) => tryUpdate((a, b, _, d, e, f) => (a, b, c, d, e, f))
+      case Success(c)  => tryUpdate((a, b, _, d, e, f) => (a, b, c, d, e, f))
       case Failure(ex) => promise.tryFailure(ex)
     }
 
     fd.onComplete {
-      case Success(d) => tryUpdate((a, b, c, _, e, f) => (a, b, c, d, e, f))
+      case Success(d)  => tryUpdate((a, b, c, _, e, f) => (a, b, c, d, e, f))
       case Failure(ex) => promise.tryFailure(ex)
     }
 
     fe.onComplete {
-      case Success(e) => tryUpdate((a, b, c, d, _, f) => (a, b, c, d, e, f))
+      case Success(e)  => tryUpdate((a, b, c, d, _, f) => (a, b, c, d, e, f))
       case Failure(ex) => promise.tryFailure(ex)
     }
 
     ff.onComplete {
-      case Success(f) => tryUpdate((a, b, c, d, e, _) => (a, b, c, d, e, f))
+      case Success(f)  => tryUpdate((a, b, c, d, e, _) => (a, b, c, d, e, f))
       case Failure(ex) => promise.tryFailure(ex)
     }
 
     promise.future
   }
-
 
   def map2[A, B, R](fa: Future[A], fb: Future[B])(f: (A, B) => R): Future[R] =
     product(fa, fb).map(f.tupled)
@@ -225,13 +242,19 @@ object Combining {
   def map4[A, B, C, D, R](fa: Future[A], fb: Future[B], fc: Future[C], fd: Future[D])(f: (A, B, C, D) => R): Future[R] =
     product(fa, fb, fc, fd).map(f.tupled)
 
-  def map5[A, B, C, D, E, R](fa: Future[A], fb: Future[B], fc: Future[C], fd: Future[D], fe: Future[E])(f: (A, B, C, D, E) => R): Future[R] =
+  def map5[A, B, C, D, E, R](fa: Future[A], fb: Future[B], fc: Future[C], fd: Future[D], fe: Future[E])(
+      f: (A, B, C, D, E) => R
+  ): Future[R] =
     product(fa, fb, fc, fd, fe).map(f.tupled)
 
-  def map6[A, B, C, D, E, F, R](fa: Future[A], fb: Future[B], fc: Future[C], fd: Future[D], fe: Future[E], ff: Future[F])(f: (A, B, C, D, E, F) => R): Future[R] =
+  def map6[A, B, C, D, E, F, R](fa: Future[A],
+                                fb: Future[B],
+                                fc: Future[C],
+                                fd: Future[D],
+                                fe: Future[E],
+                                ff: Future[F]
+  )(f: (A, B, C, D, E, F) => R): Future[R] =
     product(fa, fb, fc, fd, fe, ff).map(f.tupled)
-
-
 
   def flatMap2[A, B, R](fa: Future[A], fb: Future[B])(f: (A, B) => Future[R]): Future[R] =
     product(fa, fb).flatMap(f.tupled)
@@ -239,13 +262,23 @@ object Combining {
   def flatMap3[A, B, C, R](fa: Future[A], fb: Future[B], fc: Future[C])(f: (A, B, C) => Future[R]): Future[R] =
     product(fa, fb, fc).flatMap(f.tupled)
 
-  def flatMap4[A, B, C, D, R](fa: Future[A], fb: Future[B], fc: Future[C], fd: Future[D])(f: (A, B, C, D) => Future[R]): Future[R] =
+  def flatMap4[A, B, C, D, R](fa: Future[A], fb: Future[B], fc: Future[C], fd: Future[D])(
+      f: (A, B, C, D) => Future[R]
+  ): Future[R] =
     product(fa, fb, fc, fd).flatMap(f.tupled)
 
-  def flatMap5[A, B, C, D, E, R](fa: Future[A], fb: Future[B], fc: Future[C], fd: Future[D], fe: Future[E])(f: (A, B, C, D, E) => Future[R]): Future[R] =
+  def flatMap5[A, B, C, D, E, R](fa: Future[A], fb: Future[B], fc: Future[C], fd: Future[D], fe: Future[E])(
+      f: (A, B, C, D, E) => Future[R]
+  ): Future[R] =
     product(fa, fb, fc, fd, fe).flatMap(f.tupled)
 
-  def flatMap6[A, B, C, D, E, F, R](fa: Future[A], fb: Future[B], fc: Future[C], fd: Future[D], fe: Future[E], ff: Future[F])(f: (A, B, C, D, E, F) => Future[R]): Future[R] =
+  def flatMap6[A, B, C, D, E, F, R](fa: Future[A],
+                                    fb: Future[B],
+                                    fc: Future[C],
+                                    fd: Future[D],
+                                    fe: Future[E],
+                                    ff: Future[F]
+  )(f: (A, B, C, D, E, F) => Future[R]): Future[R] =
     product(fa, fb, fc, fd, fe, ff).flatMap(f.tupled)
 
 }

--- a/src/main/scala/markatta/futiles/Lifting.scala
+++ b/src/main/scala/markatta/futiles/Lifting.scala
@@ -22,77 +22,74 @@ import scala.util.{Failure, Success, Try}
 
 final case class UnliftException(msg: String) extends RuntimeException(msg) with NoStackTrace
 
-/**
- * For lack of a better word, lifting and unlifting is boxing or unboxing other monady types inside of futures
- */
+/** For lack of a better word, lifting and unlifting is boxing or unboxing other monady types inside of futures
+  */
 object Lifting {
 
-  /**
-   * Lifts the Try that is inside of the Future implementation to a Try that is inside the future.
-   *
-   * @return A future that always is successful, that will contain any exceptions inside of the nested Try
-   */
+  /** Lifts the Try that is inside of the Future implementation to a Try that is inside the future.
+    *
+    * @return
+    *   A future that always is successful, that will contain any exceptions inside of the nested Try
+    */
   def liftTry[A](future: Future[A]): Future[Try[A]] =
     future
       .map(Success.apply)(CallingThreadExecutionContext)
-      .recover {
-        case x: Exception => Failure(x)
+      .recover { case x: Exception =>
+        Failure(x)
       }(CallingThreadExecutionContext)
 
-
-  /**
-   * Unlifts a Future(Some(a)) into Future(a) and Future(None) into a failed future with a
-   * [[UnliftException]]
-   * @param exceptionMessageOnNone The message put in the exception
-   */
+  /** Unlifts a Future(Some(a)) into Future(a) and Future(None) into a failed future with a [[UnliftException]]
+    * @param exceptionMessageOnNone
+    *   The message put in the exception
+    */
   def unliftOption[A](future: Future[Option[A]], exceptionMessageOnNone: => String): Future[A] =
     unliftOptionEx[A](future, new UnliftException(exceptionMessageOnNone))
 
-
-  /**
-   * Unlifts a Future(Some(a)) into Future(a) and Future(None) into a failed future with a
-   * [[UnliftException]]
-   * @param exceptionBlock The exception to fail the future with for None
-   */
+  /** Unlifts a Future(Some(a)) into Future(a) and Future(None) into a failed future with a [[UnliftException]]
+    * @param exceptionBlock
+    *   The exception to fail the future with for None
+    */
   def unliftOptionEx[A](future: Future[Option[A]], exceptionBlock: => Exception): Future[A] =
     future.map(_.getOrElse(throw exceptionBlock))(CallingThreadExecutionContext)
 
-  /**
-   * Unlifts Future(Left(a)) into Future(a) and Future(Right(_)) into a future failed with [[UnliftException]]
-   * @param exceptionMessageOnRight The message to put in the exception
-   */
+  /** Unlifts Future(Left(a)) into Future(a) and Future(Right(_)) into a future failed with [[UnliftException]]
+    * @param exceptionMessageOnRight
+    *   The message to put in the exception
+    */
   def unliftL[A, B](future: Future[Either[A, B]], exceptionMessageOnRight: => String): Future[A] =
     unliftLEx(future, new UnliftException(exceptionMessageOnRight))
 
-  /**
-   * Unlifts Future(Left(a)) into Future(a) and Future(Right(_)) into a future failed with the given exception
-   */
+  /** Unlifts Future(Left(a)) into Future(a) and Future(Right(_)) into a future failed with the given exception
+    */
   def unliftLEx[A, B](future: Future[Either[A, B]], exceptionOnRight: => Exception): Future[A] =
-    future.map(_.fold(
-      identity,
-      _ => throw exceptionOnRight
-    ))(CallingThreadExecutionContext)
+    future.map(
+      _.fold(
+        identity,
+        _ => throw exceptionOnRight
+      )
+    )(CallingThreadExecutionContext)
 
-  /**
-   * Unlifts Future(Left(_)) into a future failed with UnliftException and and Future(Right(b)) into a Future(b)
-   * @param exceptionMessageOnLeft The message to put in the exception
-   */
+  /** Unlifts Future(Left(_)) into a future failed with UnliftException and and Future(Right(b)) into a Future(b)
+    * @param exceptionMessageOnLeft
+    *   The message to put in the exception
+    */
   def unliftR[A, B](future: Future[Either[A, B]], exceptionMessageOnLeft: => String): Future[B] =
     unliftREx(future, new UnliftException(exceptionMessageOnLeft))
 
-  /**
-   * Unlifts Future(Left(_)) into a future failed with the given exception and and Future(Right(b)) into a Future(b)
-   */
+  /** Unlifts Future(Left(_)) into a future failed with the given exception and and Future(Right(b)) into a Future(b)
+    */
   def unliftREx[A, B](future: Future[Either[A, B]], exceptionOnLeft: => Exception): Future[B] =
-    future.map(_.fold(
-      _ => throw exceptionOnLeft,
-      identity
-    ))(CallingThreadExecutionContext)
-
+    future.map(
+      _.fold(
+        _ => throw exceptionOnLeft,
+        identity
+      )
+    )(CallingThreadExecutionContext)
 
   object Implicits {
 
     implicit class FutureOptDecorator[A](future: Future[Option[A]]) {
+
       /** @return Future(a) if the option is Some(a), a failed future with the given message if None */
       def unlift(exceptionMessageOnNone: => String): Future[A] =
         unliftOption[A](future, exceptionMessageOnNone)
@@ -123,6 +120,5 @@ object Lifting {
     }
 
   }
-
 
 }

--- a/src/main/scala/markatta/futiles/Retry.scala
+++ b/src/main/scala/markatta/futiles/Retry.scala
@@ -26,8 +26,7 @@ object Retry {
 
   private val alwaysRetry: Throwable => Boolean = _ => true
 
-  /**
-    * Evaluate a block that creates a future up to a specific number of times, if the future fails, decide if to retry
+  /** Evaluate a block that creates a future up to a specific number of times, if the future fails, decide if to retry
     * using the shouldRetry predicate, if it returns true - retry else return the failed future.
     *
     * Default is to retry for all throwables.
@@ -35,73 +34,70 @@ object Retry {
     * Any exception in the block creating the future will never be retried but always be returned as a failed future
     */
   def retry[A](times: Int, shouldRetry: Throwable => Boolean = alwaysRetry)(
-    fBlock: => Future[A]
+      fBlock: => Future[A]
   )(implicit ec: ExecutionContext): Future[A] =
-    try {
+    try
       if (times <= 1) fBlock
       else
         fBlock.recoverWith {
           case x: Throwable if shouldRetry(x) =>
             retry(times - 1, shouldRetry)(fBlock)
         }
-    } catch {
+    catch {
       // failure to actually create the future
       case x: Throwable => Future.failed(x)
     }
 
-  /**
-    * Evaluate a block that creates a future up to a specific number of times, if the future fails, decide
-    * about retrying using a predicate, if it should retry an exponential back off is applied so that the
-    * retry waits longer and longer for every retry it makes. A jitter is also added so that the exact timing of
-    * the retry isn't exactly the same for all calls with the same backOffUnit
+  /** Evaluate a block that creates a future up to a specific number of times, if the future fails, decide about
+    * retrying using a predicate, if it should retry an exponential back off is applied so that the retry waits longer
+    * and longer for every retry it makes. A jitter is also added so that the exact timing of the retry isn't exactly
+    * the same for all calls with the same backOffUnit
     *
-    * Any exception in the block creating the future will also be returned as a failed future
-    * Default is to retry for all throwables.
+    * Any exception in the block creating the future will also be returned as a failed future Default is to retry for
+    * all throwables.
     *
-    * Based on this wikipedia article:
-    * http://en.wikipedia.org/wiki/Truncated_binary_exponential_backoff
+    * Based on this wikipedia article: http://en.wikipedia.org/wiki/Truncated_binary_exponential_backoff
     */
   def retryWithBackOff[A](
-    times: Int,
-    backOffUnit: FiniteDuration,
-    shouldRetry: Throwable => Boolean = alwaysRetry
+      times: Int,
+      backOffUnit: FiniteDuration,
+      shouldRetry: Throwable => Boolean = alwaysRetry
   )(fBlock: => Future[A])(implicit ec: ExecutionContext): Future[A] =
-    try {
+    try
       if (times <= 1) fBlock
       else retryWithBackOffLoop(times, 1, backOffUnit, shouldRetry)(fBlock)
-    } catch {
+    catch {
       // failure to actually create the future
       case x: Throwable => Future.failed(x)
     }
 
   private def retryWithBackOffLoop[A](
-    totalTimes: Int,
-    timesTried: Int,
-    backOffUnit: FiniteDuration,
-    shouldRetry: Throwable => Boolean
+      totalTimes: Int,
+      timesTried: Int,
+      backOffUnit: FiniteDuration,
+      shouldRetry: Throwable => Boolean
   )(fBlock: => Future[A])(implicit ec: ExecutionContext): Future[A] =
     if (totalTimes <= timesTried) fBlock
     else
       fBlock.recoverWith {
         case ex: Throwable if shouldRetry(ex) =>
           val timesTriedNow = timesTried + 1
-          val backOff = nextBackOff(timesTriedNow, backOffUnit)
+          val backOff       = nextBackOff(timesTriedNow, backOffUnit)
           Timeouts
             .timeout(backOff)(())
-            .flatMap(
-              _ =>
-                retryWithBackOffLoop(
-                  totalTimes,
-                  timesTriedNow,
-                  backOffUnit,
-                  shouldRetry
-                )(fBlock)
+            .flatMap(_ =>
+              retryWithBackOffLoop(
+                totalTimes,
+                timesTriedNow,
+                backOffUnit,
+                shouldRetry
+              )(fBlock)
             )
       }
 
   private[futiles] def nextBackOff(
-    tries: Int,
-    backOffUnit: FiniteDuration
+      tries: Int,
+      backOffUnit: FiniteDuration
   ): FiniteDuration = {
     require(tries > 0, "tries should start from 1")
     val rng = new Random(ThreadLocalRandom.current())

--- a/src/test/scala/markatta/futiles/BooleanSpec.scala
+++ b/src/test/scala/markatta/futiles/BooleanSpec.scala
@@ -28,29 +28,28 @@ class BooleanSpec extends Spec {
       val t = Future.successful(true)
       val f = Future.successful(false)
 
-      (t && t).futureValue should be (true)
-      (t && f).futureValue should be (false)
-      (f && t).futureValue should be (false)
-      (f && f).futureValue should be (false)
+      (t && t).futureValue should be(true)
+      (t && f).futureValue should be(false)
+      (f && t).futureValue should be(false)
+      (f && f).futureValue should be(false)
     }
-
 
     it("gives the expected result from 'or' with two booleans") {
       val t = Future.successful(true)
       val f = Future.successful(false)
 
-      (t || t).futureValue should be (true)
-      (t || f).futureValue should be (true)
-      (f || t).futureValue should be (true)
-      (f || f).futureValue should be (false)
+      (t || t).futureValue should be(true)
+      (t || f).futureValue should be(true)
+      (f || t).futureValue should be(true)
+      (f || f).futureValue should be(false)
     }
 
     it("can negate a boolean") {
       val t = Future.successful(true)
       val f = Future.successful(false)
 
-      (!t).futureValue should be (false)
-      (!f).futureValue should be (true)
+      (!t).futureValue should be(false)
+      (!f).futureValue should be(true)
     }
 
   }

--- a/src/test/scala/markatta/futiles/CombiningSpec.scala
+++ b/src/test/scala/markatta/futiles/CombiningSpec.scala
@@ -43,7 +43,9 @@ class CombiningSpec extends Spec {
       }
 
       it("fails fast three on combining futures into a tuple3") {
-        product(Promise().future, Promise().future, failed(new RuntimeException("argh"))).failed.futureValue shouldBe a[RuntimeException]
+        product(Promise().future, Promise().future, failed(new RuntimeException("argh"))).failed.futureValue shouldBe a[
+          RuntimeException
+        ]
       }
 
       it("combines two successful and one failed futures into a failure") {
@@ -61,21 +63,33 @@ class CombiningSpec extends Spec {
       }
 
       it("combines five successful futures into a tuple5") {
-        product(successful(1), successful(2), successful(3), successful(4), successful(5)).futureValue should be((1, 2, 3, 4, 5))
+        product(successful(1), successful(2), successful(3), successful(4), successful(5)).futureValue should be(
+          (1, 2, 3, 4, 5)
+        )
       }
 
       it("combines four successful and one failed futures into a failure") {
         val ex = new RuntimeException("bah")
-        liftTry(product(successful(1), successful(2), successful(3), successful(4), failed(ex))).futureValue should be(Failure(ex))
+        liftTry(product(successful(1), successful(2), successful(3), successful(4), failed(ex))).futureValue should be(
+          Failure(ex)
+        )
       }
 
       it("combines six successful futures into a tuple6") {
-        product(successful(1), successful(2), successful(3), successful(4), successful(5), successful(6)).futureValue should be((1, 2, 3, 4, 5, 6))
+        product(successful(1),
+                successful(2),
+                successful(3),
+                successful(4),
+                successful(5),
+                successful(6)
+        ).futureValue should be((1, 2, 3, 4, 5, 6))
       }
 
       it("combines five successful and one failed futures into a failure") {
         val ex = new RuntimeException("bah")
-        liftTry(product(successful(1), successful(2), successful(3), successful(4), successful(5), failed(ex))).futureValue should be(Failure(ex))
+        liftTry(
+          product(successful(1), successful(2), successful(3), successful(4), successful(5), failed(ex))
+        ).futureValue should be(Failure(ex))
       }
     }
 
@@ -90,15 +104,21 @@ class CombiningSpec extends Spec {
       }
 
       it("maps four successful futures into a result using a function") {
-        map4(successful(1), successful(2), successful(3), successful(4))((a, b, c, d) => a + b + c + d).futureValue should be(10)
+        map4(successful(1), successful(2), successful(3), successful(4))((a, b, c, d) =>
+          a + b + c + d
+        ).futureValue should be(10)
       }
 
       it("maps five successful futures into a result using a function") {
-        map5(successful(1), successful(2), successful(3), successful(4), successful(5))((a, b, c, d, e) => a + b + c + d + e).futureValue should be(15)
+        map5(successful(1), successful(2), successful(3), successful(4), successful(5))((a, b, c, d, e) =>
+          a + b + c + d + e
+        ).futureValue should be(15)
       }
 
       it("maps six successful futures into a result using a function") {
-        map6(successful(1), successful(2), successful(3), successful(4), successful(5), successful(6))((a, b, c, d, e, f) => a + b + c + d + e + f).futureValue should be(21)
+        map6(successful(1), successful(2), successful(3), successful(4), successful(5), successful(6))(
+          (a, b, c, d, e, f) => a + b + c + d + e + f
+        ).futureValue should be(21)
       }
 
     }
@@ -110,19 +130,27 @@ class CombiningSpec extends Spec {
       }
 
       it("flatMaps three successful futures into a result using a function") {
-        flatMap3(successful(1), successful(2), successful(3))((a, b, c) => successful(a + b + c)).futureValue should be(6)
+        flatMap3(successful(1), successful(2), successful(3))((a, b, c) => successful(a + b + c)).futureValue should be(
+          6
+        )
       }
 
       it("flatMaps four successful futures into a result using a function") {
-        flatMap4(successful(1), successful(2), successful(3), successful(4))((a, b, c, d) => successful(a + b + c + d)).futureValue should be(10)
+        flatMap4(successful(1), successful(2), successful(3), successful(4))((a, b, c, d) =>
+          successful(a + b + c + d)
+        ).futureValue should be(10)
       }
 
       it("flatMaps five successful futures into a result using a function") {
-        flatMap5(successful(1), successful(2), successful(3), successful(4), successful(5))((a, b, c, d, e) => successful(a + b + c + d + e)).futureValue should be(15)
+        flatMap5(successful(1), successful(2), successful(3), successful(4), successful(5))((a, b, c, d, e) =>
+          successful(a + b + c + d + e)
+        ).futureValue should be(15)
       }
 
       it("flatMaps six successful futures into a result using a function") {
-        flatMap6(successful(1), successful(2), successful(3), successful(4), successful(5), successful(6))((a, b, c, d, e, f) => successful(a + b + c + d + e + f)).futureValue should be(21)
+        flatMap6(successful(1), successful(2), successful(3), successful(4), successful(5), successful(6))(
+          (a, b, c, d, e, f) => successful(a + b + c + d + e + f)
+        ).futureValue should be(21)
       }
     }
 

--- a/src/test/scala/markatta/futiles/LiftingSpec.scala
+++ b/src/test/scala/markatta/futiles/LiftingSpec.scala
@@ -17,7 +17,7 @@
 package markatta.futiles
 
 import scala.concurrent.Future
-import scala.concurrent.Future.{successful,failed}
+import scala.concurrent.Future.{successful, failed}
 import scala.util.{Try, Success, Failure}
 
 class LiftingSpec extends Spec {
@@ -26,34 +26,32 @@ class LiftingSpec extends Spec {
 
   describe("The lifting utilities for futures") {
 
-
     describe("the Try lifter") {
 
       it("lifts a failed future") {
-        val exception = new RuntimeException("error")
+        val exception                   = new RuntimeException("error")
         val result: Future[Try[String]] = liftTry(failed[String](exception))
 
-        result.futureValue should be (Failure(exception))
+        result.futureValue should be(Failure(exception))
       }
 
       it("lifts a successful future") {
         val result: Future[Try[String]] = liftTry(successful("Success"))
-        result.futureValue should be (Success("Success"))
+        result.futureValue should be(Success("Success"))
       }
 
     }
-
 
     describe("the Option unlifter") {
 
       it("unlifts None into an UnliftException") {
         val result = unliftOption(successful[Option[String]](None), "missing!")
-        liftTry(result).futureValue should be (Failure(new UnliftException("missing!")))
+        liftTry(result).futureValue should be(Failure(new UnliftException("missing!")))
       }
 
       it("unlifts a Some(value) into value") {
         val result = unliftOption(successful[Option[String]](Some("woho")), "missing")
-        result.futureValue should be ("woho")
+        result.futureValue should be("woho")
       }
 
     }
@@ -62,18 +60,18 @@ class LiftingSpec extends Spec {
       import Lifting.Implicits._
       it("unlifts None into an UnliftException") {
         val result = successful[Option[String]](None).unlift("missing!")
-        liftTry(result).futureValue should be (Failure(new UnliftException("missing!")))
+        liftTry(result).futureValue should be(Failure(new UnliftException("missing!")))
       }
 
       it("unlifts None into a custom exception") {
-        val ex = new RuntimeException("dang")
+        val ex     = new RuntimeException("dang")
         val result = successful[Option[String]](None).unliftEx(ex)
-        liftTry(result).futureValue should be (Failure(ex))
+        liftTry(result).futureValue should be(Failure(ex))
       }
 
       it("unlifts a Some(value) into value") {
         val result = successful[Option[String]](Some("woho")).unlift("missing!")
-        result.futureValue should be ("woho")
+        result.futureValue should be("woho")
       }
     }
 
@@ -81,12 +79,12 @@ class LiftingSpec extends Spec {
 
       it("unlifts a Left into its value") {
         val result = unliftL(successful(Left("woho")), "missing")
-        result.futureValue should be ("woho")
+        result.futureValue should be("woho")
       }
 
       it("unlifts a Right into an exception") {
         val result = liftTry(unliftL(successful(Right("woho")), "missing"))
-        result.futureValue should be (Failure(new UnliftException("missing")))
+        result.futureValue should be(Failure(new UnliftException("missing")))
       }
 
     }
@@ -95,53 +93,50 @@ class LiftingSpec extends Spec {
       import Lifting.Implicits.FutureEitherDecorator
       it("unlifts a Left into its value") {
         val result = successful(Left("woho")).unliftL("missing")
-        result.futureValue should be ("woho")
+        result.futureValue should be("woho")
       }
 
       it("unlifts a Right into an exception") {
         val result = liftTry(successful(Right("woho")).unliftL("missing"))
-        result.futureValue should be (Failure(new UnliftException("missing")))
+        result.futureValue should be(Failure(new UnliftException("missing")))
       }
 
       it("unlifts a Right into a custom exception") {
-        val ex = new RuntimeException("darnit")
+        val ex     = new RuntimeException("darnit")
         val result = liftTry(successful(Right("woho")).unliftLEx(ex))
-        result.futureValue should be (Failure(ex))
+        result.futureValue should be(Failure(ex))
       }
     }
-
 
     describe("the Right unlifting") {
 
       it("unlifts a Right into its value") {
         val result = unliftR(successful(Right("woho")), "missing")
-        result.futureValue should be ("woho")
+        result.futureValue should be("woho")
       }
 
       it("unlifts a Left into an exception") {
         val result = liftTry(unliftR(successful(Left("woho")), "missing"))
-        result.futureValue should be (Failure(new UnliftException("missing")))
+        result.futureValue should be(Failure(new UnliftException("missing")))
       }
     }
-
 
     describe("the implicit Right unlifting") {
       import Lifting.Implicits.FutureEitherDecorator
       it("unlifts a Right into its value") {
         val result = successful(Right("woho")).unliftR("missing")
-        result.futureValue should be ("woho")
+        result.futureValue should be("woho")
       }
 
       it("unlifts a Left into an exception") {
         val result = liftTry(successful(Left("woho")).unliftR("missing"))
-        result.futureValue should be (Failure(new UnliftException("missing")))
+        result.futureValue should be(Failure(new UnliftException("missing")))
       }
 
-
       it("unlifts a Left into a custom exception") {
-        val ex = new RuntimeException("bork bork")
+        val ex     = new RuntimeException("bork bork")
         val result = liftTry(successful(Left("woho")).unliftREx(ex))
-        result.futureValue should be (Failure(ex))
+        result.futureValue should be(Failure(ex))
       }
     }
 

--- a/src/test/scala/markatta/futiles/RetryAnalysis.scala
+++ b/src/test/scala/markatta/futiles/RetryAnalysis.scala
@@ -10,15 +10,13 @@ import scala.concurrent.duration._
 object RetryAnalysis extends App {
 
   val file = new File("./data.tsv")
-  val p = new java.io.PrintWriter(file)
+  val p    = new java.io.PrintWriter(file)
 
-  val range = (1 to 10)
-  val unit = 1.second
+  val range = 1 to 10
+  val unit  = 1.second
 
   val result = range.flatMap { n =>
-    (0 to 1000).map(
-      _ => p.println(s"$n\t${Retry.nextBackOff(n, unit).toMillis}")
-    )
+    (0 to 1000).map(_ => p.println(s"$n\t${Retry.nextBackOff(n, unit).toMillis}"))
   }
 
   println(s"Wrote $file")

--- a/src/test/scala/markatta/futiles/RetrySpec.scala
+++ b/src/test/scala/markatta/futiles/RetrySpec.scala
@@ -70,7 +70,7 @@ class RetrySpec extends Spec {
         whenReady(liftTry(result)) { fail =>
           fail shouldBe a[Failure[_]]
         }
-        invocations.get() shouldBe (1)
+        invocations.get() shouldBe 1
       }
 
     }
@@ -92,7 +92,7 @@ class RetrySpec extends Spec {
       }
 
       it("returns the first success but has backed off") {
-        val count = new AtomicInteger(0)
+        val count  = new AtomicInteger(0)
         val before = System.currentTimeMillis
         val result = retryWithBackOff(5, 5.millisecond) {
           if (count.incrementAndGet() > 2) successful(System.currentTimeMillis)
@@ -114,12 +114,10 @@ class RetrySpec extends Spec {
         whenReady(liftTry(result)) { fail =>
           fail shouldBe a[Failure[_]]
         }
-        invocations.get() shouldBe (1)
+        invocations.get() shouldBe 1
       }
     }
 
   }
-
-
 
 }

--- a/src/test/scala/markatta/futiles/Spec.scala
+++ b/src/test/scala/markatta/futiles/Spec.scala
@@ -22,6 +22,6 @@ import org.scalatest.{FunSpec, Matchers}
 import scala.concurrent.duration._
 
 abstract class Spec extends FunSpec with Matchers with ScalaFutures {
-  implicit val ec = scala.concurrent.ExecutionContext.Implicits.global
+  implicit val ec                                      = scala.concurrent.ExecutionContext.Implicits.global
   override implicit def patienceConfig: PatienceConfig = PatienceConfig(1.second, 100.millis)
 }

--- a/src/test/scala/markatta/futiles/TimeoutsSpec.scala
+++ b/src/test/scala/markatta/futiles/TimeoutsSpec.scala
@@ -28,7 +28,7 @@ class TimeoutsSpec extends Spec {
 
     it("runs a future after a given timeout") {
       val result = Timeouts.timeout(2.millis)("success")
-      result.futureValue should be ("success")
+      result.futureValue should be("success")
     }
 
     it("decorates a future with an error timeout") {
@@ -42,7 +42,7 @@ class TimeoutsSpec extends Spec {
     }
 
     it("completes a future rathern than fail it if it does not timeout") {
-      Future.successful("success").withTimeoutError(10.seconds).futureValue should be ("success")
+      Future.successful("success").withTimeoutError(10.seconds).futureValue should be("success")
     }
 
     it("decorates a future with an default timeout") {
@@ -53,7 +53,7 @@ class TimeoutsSpec extends Spec {
     }
 
     it("completes a future rathern than default it if it does not timeout") {
-      Future.successful("success").withTimeoutDefault(10.seconds, "default").futureValue should be ("success")
+      Future.successful("success").withTimeoutDefault(10.seconds, "default").futureValue should be("success")
     }
   }
 }

--- a/src/test/scala/markatta/futiles/TraversalSpec.scala
+++ b/src/test/scala/markatta/futiles/TraversalSpec.scala
@@ -59,13 +59,12 @@ class TraversalSpec extends Spec {
 
     it("executes the futures sequentially") {
       val latch = new CountDownLatch(3)
-      val result = foldLeftSequentially(List(1, 2, 3))(Seq.empty[Int]) {
-        (acc, n) =>
-          Future {
-            latch.countDown()
-            val l = latch.getCount.toInt
-            acc :+ l
-          }
+      val result = foldLeftSequentially(List(1, 2, 3))(Seq.empty[Int]) { (acc, n) =>
+        Future {
+          latch.countDown()
+          val l = latch.getCount.toInt
+          acc :+ l
+        }
       }
 
       result.futureValue should be(List(2, 1, 0))
@@ -74,14 +73,13 @@ class TraversalSpec extends Spec {
 
     it("executes fails if one of the futures fails") {
       val latch = new CountDownLatch(3)
-      val result = foldLeftSequentially(List(1, 2, 3))(Seq.empty[Int]) {
-        (acc, n) =>
-          Future {
-            latch.countDown()
-            val l = latch.getCount.toInt
-            if (l == 1) throw new RuntimeException("fail")
-            acc :+ l
-          }
+      val result = foldLeftSequentially(List(1, 2, 3))(Seq.empty[Int]) { (acc, n) =>
+        Future {
+          latch.countDown()
+          val l = latch.getCount.toInt
+          if (l == 1) throw new RuntimeException("fail")
+          acc :+ l
+        }
       }
 
       Lifting.liftTry(result).futureValue.isFailure should be(true)


### PR DESCRIPTION
Does the following

1. Adds scalafmt and the sbt-scalafmt plugin
2. Adds a github actions pipeline that uses scalafmt-native which can check that the entire project is formatted in ~5 seconds. It also runs concurrently to the main CDP build
3. Applies scalafmt

In regards to the `.scalafmt.conf` configuration, I just used some generic configuration but if you want to use a different one than let me know and I can update and rebase it.