### PR TITLE
Updates scalac flags to be optimal

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,47 @@ ThisBuild / organization := "com.markatta"
 
 ThisBuild / crossScalaVersions := Seq("2.12.15", "2.11.12", "2.13.8")
 ThisBuild / scalaVersion       := crossScalaVersions.value.last
-ThisBuild / scalacOptions ++= Seq("-feature", "-deprecation", "-Xfatal-warnings", "-Xlint")
+
+val flagsFor11 = Seq(
+  "-Xlint:_",
+  "-feature",
+  "-deprecation",
+  "-Yconst-opt",
+  "-Ywarn-infer-any",
+  "-Yclosure-elim",
+  "-Ydead-code"
+)
+
+val flagsFor12 = Seq(
+  "-Xlint:_",
+  "-feature",
+  "-deprecation",
+  "-Ywarn-infer-any",
+  "-Ywarn-adapted-args", // Warn if an argument list is modified to match the receiver
+  "-Ywarn-inaccessible",
+  "-Ywarn-infer-any",
+  "-opt-inline-from:<sources>",
+  "-opt:l:method"
+)
+
+val flagsFor13 = Seq(
+  "-Xlint:_",
+  "-feature",
+  "-deprecation",
+  "-opt-inline-from:<sources>",
+  "-opt:l:method"
+)
+
+ThisBuild / scalacOptions ++= {
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, n)) if n == 13 =>
+      flagsFor13
+    case Some((2, n)) if n == 12 =>
+      flagsFor12
+    case Some((2, n)) if n == 11 =>
+      flagsFor11
+  }
+}
 
 libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.0.8" % "test")
 


### PR DESCRIPTION
This PR updates the flags so they are more optimal. Of note are the

```
  "-opt-inline-from:<sources>",
  "-opt:l:method"
 ```

Flags which according to scalac documentation is the recommended and safe in-lining option for scala libraries for 2.12/2.13