### PR TITLE
Delete unneeded coveralls.sbt

### DIFF
--- a/project/coveralls.sbt
+++ b/project/coveralls.sbt
@@ -1,7 +1,0 @@
-resolvers += Classpaths.sbtPluginReleases
-
-// not supported for sbt 1.0 yet
-// addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
-// addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
-
-// token for interaction is in travis-ci env variable


### PR DESCRIPTION
This was added into `plugins.sbt`. Alternately if you want to keep this build structure I can move the associated plugins from `plugins.sbt` into `coveralls.sbt`.