### PR TITLE
Replace travis badge with github-actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Futiles
 
 [![Join the chat at https://gitter.im/johanandren/futiles](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/johanandren/futiles?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Build Status](https://travis-ci.org/johanandren/futiles.svg)](https://travis-ci.org/johanandren/futiles)
+[![Build Status](https://github.com/johanandren/futiles/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/johanandren/futiles/actions/workflows/ci.yml?query=branch%3Amain)
 [![Coverage Status](https://coveralls.io/repos/johanandren/futiles/badge.svg?branch=master)](https://coveralls.io/r/johanandren/futiles?branch=master)
 [![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
 


### PR DESCRIPTION
Replaces the travis badge with github actions. Also the badge/link only checks that the main branch is passing rather than globally every branch.