### PR TITLE
Add JDK8/JDK17 into CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.12.15, 2.11.12, 2.13.8]
-        java: [temurin@11]
+        java: [temurin@11, temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -37,6 +37,13 @@ jobs:
         with:
           distribution: temurin
           java-version: 11
+
+      - name: Setup Java (temurin@17)
+        if: matrix.java == 'temurin@17'
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 17
 
       - name: Cache sbt
         uses: actions/cache@v2

--- a/build.sbt
+++ b/build.sbt
@@ -68,6 +68,11 @@ developers := List(
   Developer("johanandren", "Johan Andrén", "johan@markatta.com", url("https://markatta.com/johan/codemonkey"))
 )
 
+ThisBuild / githubWorkflowJavaVersions := List(
+  JavaSpec.temurin("11"),
+  JavaSpec.temurin("17")
+)
+
 // Disable publish for now
 ThisBuild / githubWorkflowPublishTargetBranches := Seq()
 


### PR DESCRIPTION
This PR adds JDK8/JDK17 into the CI build matrix. Remember to also update the github branch status checks after the PR gets merged.